### PR TITLE
デプロイ調整7.5.6

### DIFF
--- a/app/controllers/chats_controller.rb
+++ b/app/controllers/chats_controller.rb
@@ -1,6 +1,7 @@
 require "net/http"
 require "uri"
 class ChatsController < ApplicationController
+  protect_from_forgery with: :exception
   def index
     user = current_user
     chat_session_id = session[:chat_session_id]


### PR DESCRIPTION
chatsコントローラにCSRF保護を有効にする``protect_from_forgery with: :exception``を追加