### PR TITLE
デプロイ調整8

### DIFF
--- a/app/controllers/chats_controller.rb
+++ b/app/controllers/chats_controller.rb
@@ -77,10 +77,10 @@ class ChatsController < ApplicationController
     user_message = Message.create(user: user, chat_session: chat_session, content: message)
 
     # 開発時に使用するチャットのURL
-    # uri = URI.parse("http://localhost:3001/chats")
+    uri = URI.parse("http://localhost:3001/chat")
 
     # デプロイ時に使用するチャットのURL
-    uri = URI.parse("https://ai-dialogue-app-1.onrender.com/chats")
+    # uri = URI.parse("https://ai-dialogue-app-1.onrender.com:3001/chat")
 
     chat_history = chat_session.messages.order(created_at: :asc).map do |message|
       gemini_response = message.ai_response
@@ -105,6 +105,7 @@ class ChatsController < ApplicationController
       score = gemini_data["score"]
 
       AiResponse.create(message: user_message, content: gemini_response)
+
        if is_last_message && score.present?
           score_record = Score.create(chat_session: chat_session, score: score.to_i) # スコアを保存
           session[:chat_score] = score_record.score

--- a/gemini.mjs
+++ b/gemini.mjs
@@ -12,14 +12,14 @@ const genAI = new GoogleGenerativeAI(API_KEY)
 
 // アクセス許可
 app.use((req, res, next) => {
-  res.header("Access-Controll-Allow-Origin", "*");
-  res.header("Access-Controll-Allow-Methods", "GET, POST, PUT, DELETE");
-  res.header("Access-Controll-Allow-Headers", "Content-Type");
+  res.header("Access-Control-Allow-Origin", "*");
+  res.header("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE");
+  res.header("Access-Control-Allow-Headers", "Content-Type");
   next();
 });
 
 // チャットのエンドポイント
-app.post("/chats", async (req, res) => {
+app.post("/chat", async (req, res) => {
   try {
     const userInput = req.body.message;
     const theme = req.body.theme;

--- a/test/controllers/scores_controller_test.rb
+++ b/test/controllers/scores_controller_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class ScoresControllerTest < ActionDispatch::IntegrationTest
   # test "should get show" do
-    # get scores_show_url
-    # assert_response :success
+  #   get scores_show_url
+  #   assert_response :success
   # end
 end


### PR DESCRIPTION
AIへの質問で内部APIへのリクエストの場合ならlocalhost:3001をNode.jsサーバーのアドレスにしたままでもデプロイしても問題ないかもとのことで試してみる。