### PR TITLE
難易度の項目並びにフリーテーマなどテーマの自動生成追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,3 +61,6 @@ end
 gem "devise"
 
 gem "dotenv-rails"
+
+# ランダムな単語生成に
+gem "faker"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,6 +115,8 @@ GEM
       railties (>= 6.1)
     drb (2.2.1)
     erubi (1.13.1)
+    faker (3.5.1)
+      i18n (>= 1.8.11, < 2)
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.6)
@@ -320,6 +322,7 @@ DEPENDENCIES
   debug
   devise
   dotenv-rails
+  faker
   jbuilder
   jsbundling-rails
   pg (~> 1.1)

--- a/app/controllers/chats_controller.rb
+++ b/app/controllers/chats_controller.rb
@@ -34,13 +34,14 @@ class ChatsController < ApplicationController
 
   def new
     user = current_user
+    difficulty = params[:difficulty]
     theme = params[:theme]
-    if theme.present?
-      chat_session = ChatSession.create(user: user, difficulty: "easy", theme: theme)
+    if difficulty.present? && theme.present?
+      chat_session = ChatSession.create(user: user, difficulty: difficulty, theme: theme)
       session[:chat_session_id] = chat_session.id
       redirect_to chats_path
     else
-      flash[:error] = "テーマを選択してください"
+      flash[:error] = "難易度とテーマを選択してください"
       redirect_to homes_path
     end
   end

--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -1,5 +1,27 @@
 class HomesController < ApplicationController
   def index
-    @theme = [ "環境問題", "AIの役割", "プログラミングの極意" ]
+    @difficulty = params[:difficulty] || "easy"
+    @themes = generate_themes(@difficulty)
+    respond_to do |format|
+      format.html
+      format.turbo_stream { render turbo_stream: turbo_stream.replace("theme_options", partial: "homes/theme_option", locals: { themes: @themes}) }
+    end
+  end
+
+  private
+
+  def generate_themes(difficulty)
+    @free_theme = difficulty == "free"
+    themes = case @difficulty
+    when "easy"
+      [Faker::Sport.sport, Faker::JapaneseMedia::StudioGhibli.movie]
+    when "normal"
+      [Faker::Book.title, Faker::Commerce.department]
+    when "hard"
+      [Faker::Color.color_name, Faker::Emotion.noun, Faker::Space.planet]
+    when "free"
+      []
+    end
+    themes
   end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,2 +1,0 @@
-class Task < ApplicationRecord
-end

--- a/app/views/homes/_theme_option.html.erb
+++ b/app/views/homes/_theme_option.html.erb
@@ -1,0 +1,7 @@
+<% if difficulty == "free" %>
+  <p>フリーテーマ入力</p>
+  <%= text_field_tag :theme, params[:theme], class: "block appearance-none w-full bg-white border border-gray-300 hover:border-gray-500 px-4 py-2 pr-8 rounded shadow leading-tight focus:outline-none focus:shadow-outline" %>
+<% else %>
+  <p>テーマ選択</p>
+  <%= select_tag "theme", options_for_select(themes), class: "block appearance-none w-full bg-white border border-gray-300 hover:border-gray-500 px-4 py-2 pr-8 rounded shadow leading-tight focus:outline-none focus:shadow-outline" %>
+<% end %>

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -16,18 +16,36 @@
   </div>
   <div class="w-1/2 p-4">
     <div class="relative inline-block text-left">
-      <p>テーマ選択</p>
-      <form action="/chats/new" method="get">
-        <select name="theme" class="block appearance-none w-full bg-white border border-gray-300 hover:border-gray-500 px-4 py-2 pr-8 rounded shadow leading-tight focus:outline-none focus:shadow-outline">
-          <% @theme.each do |theme| %>
-            <option value="<%= theme %>"><%= theme %></option>
-          <% end %>
-        </select>
-        <div class="pointer-events-none absolute inset-y-0 right-0 flex items-center px-2 text-gray-700">
-          <svg class="fill-current h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M9.293 12.95l.707.707L15.657 8l-1.414-1.414L10 10.828 5.757 6.586 4.343 8z"/></svg>
+      <p>難易度選択</p>
+        <div>
+          <%= link_to "初級", homes_path(difficulty: "easy"), class: "button", data: { turbo_frame: "theme_options" } %>
         </div>
-        <button type="submit" class="mt-4 button bg-blue-500 text-white rounded px-4 py-2">対話開始</button>
-      </form>
+        <div>
+          <%= link_to "中級", homes_path(difficulty: "normal"), class: "button", data: { turbo_frame: "theme_options" } %>
+        </div>
+        <div>
+          <%= link_to "上級", homes_path(difficulty: "hard"), class: "button", data: { turbo_frame: "theme_options" } %>
+        </div>
+        <div>
+          <%= link_to "フリーテーマ", homes_path(difficulty: "free"), class: "button", data: { turbo_frame: "theme_options" } %>
+        </div>
+
+        <%= form_with url: chats_new_path, method: :get do |form| %>
+          <div id="theme_options">
+            <% if @free_theme %>
+              <p>フリーテーマ入力</p>
+              <%= text_field_tag :theme, params[:theme], class: "block appearance-none w-full bg-white border border-gray-300 hover:border-gray-500 px-4 py-2 pr-8 rounded shadow leading-tight focus:outline-none focus:shadow-outline" %>
+            <% else %>
+              <p>テーマ選択</p>
+              <%= select_tag "theme", options_for_select(@themes), class: "block appearance-none w-full bg-white border border-gray-300 hover:border-gray-500 px-4 py-2 pr-8 rounded shadow leading-tight focus:outline-none focus:shadow-outline" %>
+            <% end %>
+          </div>
+          <%= hidden_field_tag :difficulty, @difficulty %>
+            <div class="pointer-events-none absolute inset-y-0 right-0 flex items-center px-2 text-gray-700">
+              <svg class="fill-current h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M9.293 12.95l.707.707L15.657 8l-1.414-1.414L10 10.828 5.757 6.586 4.343 8z"/></svg>
+            </div>
+        <%= form.submit "対話開始", class: "mt-4 button bg-blue-500 text-white rounded px-4 py-2" %>
+      <% end %>
     </div>
   </div>
 </main>

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,5 +23,8 @@ module Myapp
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+
+    # fakerの日本語化
+    config.i18n.default_locale = :ja
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
   # root "posts#index"
   root "top_pages#top"
   resources :homes, only: [ :index ]
+  get "homes/update_theme"
 
   # chat_session
   get "/chats", to: "chats#index"

--- a/db/migrate/20241225100032_create_tasks.rb
+++ b/db/migrate/20241225100032_create_tasks.rb
@@ -1,9 +1,0 @@
-class CreateTasks < ActiveRecord::Migration[7.2]
-  def change
-    create_table :tasks do |t|
-      t.string :name
-
-      t.timestamps
-    end
-  end
-end

--- a/db/migrate/20250214111352_drop_tasks.rb
+++ b/db/migrate/20250214111352_drop_tasks.rb
@@ -1,0 +1,5 @@
+class DropTasks < ActiveRecord::Migration[7.2]
+  def change
+    drop_table :tasks
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_01_28_085153) do
+ActiveRecord::Schema[7.2].define(version: 2025_02_14_111352) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -47,12 +47,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_28_085153) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["chat_session_id"], name: "index_scores_on_chat_session_id"
-  end
-
-  create_table "tasks", force: :cascade do |t|
-    t.string "name"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
今回はMVPリリース後の初めての更新

以前までコントローラで直接に文字列を入力していた難易度(difficulty)のカラムをユーザーが選択できるように更新
またテーマもgem 'faker'を用いてある程度自動生成されるように調整、フリーテーマという名でユーザーが直接テーマを入力できるように調整