### PR TITLE
独自ドメイン設定1.4

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -116,6 +116,6 @@ Rails.application.configure do
   }
 
   # 独自ドメイン設定
+  config.hosts << "ai-dialogue-app-1.onrender.com"
   config.hosts << "ai-dialogue.jp"
-  config.hosts << "www.ai-dialogue.jp"
 end


### PR DESCRIPTION
Renderのデフォルトのドメインがブロックされてしまうので、config.hostsにそれを追加。
また、サブドメインが設定できないかもなのでその部分は削除。