### PR TITLE
CIを編集して自動テスト化

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,12 +49,10 @@ jobs:
         ports:
           - 5432:5432
         options: --health-cmd="pg_isready" --health-interval=10s --health-timeout=5s --health-retries=3
-
-      # redis:
-      #   image: redis
-      #   ports:
-      #     - 6379:6379
-      #   options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
+      chrome:
+        image: seleniarm/standalone-chromium:114.0
+        ports:
+          - 4445:4444
 
     steps:
       - name: Install packages
@@ -69,12 +67,49 @@ jobs:
           ruby-version: .ruby-version
           bundler-cache: true
 
+      - name: Cache node modules
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Bundler and gem install
+        run: |
+          gem install bundler
+          bundler install --jobs 4 --retry 3 --path vendor/bundle
+
+      - name: Yarn install
+        run: npm install -g yarn && yarn install --check-files
+
+      - name: Check for port conflicts and set CAPYBARA_PORT
+        run: |
+          PORT=4444
+          if lsof -i:$PORT; then
+            echo "Port $PORT is in use, killing the process"
+            lsof -ti:$PORT | xargs kill -9
+          fi
+          CAPYBARA_PORT=3001
+          echo "CAPYBARA_PORT=$CAPYBARA_PORT" >> $GITHUB_ENV
+          echo "DEBUG: Capybara port set to $CAPYBARA_PORT"
+
+      - name: Datebase create and migrate
+        run: |
+          cp config/database.yml.ci config/database.yml
+          bundle exec rails db:create RAILS_ENV=test
+          bundle exec rails db:migrate RAILS_ENV=test
+
+      - name: assets precompile
+        run: bundle exec rake assets:precompile RAILS_ENV=test
+
       - name: Run tests
         env:
           RAILS_ENV: test
-          DATABASE_URL: postgres://postgres:postgres@localhost:5432
-          # REDIS_URL: redis://localhost:6379/0
-        run: bin/rails db:test:prepare test test:system
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432/myapp_test
+          SELENIUM_DRIVER_URL: http://localhost:4445/wd/hub
+          CAPYBARA_PORT: ${{ env.CAPYBARA_PORT }}
+        run: bundle exec rspec
 
       - name: Keep screenshots from failed system tests
         uses: actions/upload-artifact@v4

--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -1,6 +1,6 @@
 class HomesController < ApplicationController
   before_action :authenticate_user!
-  
+
   def index
     @error_message = session.delete(:error_message)
     @difficulty = params[:difficulty] || "easy"

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,8 +24,12 @@
       <header class="flex items-center justify-between h-24 bg-sky-950">
         <%= render "shared/header" %>
       </header>
-      <p class="notice"><%= notice %></p>
-      <p class="alert"><%= alert %></p>
+      <% if flash[:notice] %>
+        <p class="notice"><%= notice %></p>
+      <% end %>
+      <% if flash[:alert] %>
+        <p class="alert"><%= alert %></p>
+      <% end %>
       <main class="flex-grow">
         <%= yield %>
       </main>

--- a/compose.yml
+++ b/compose.yml
@@ -37,6 +37,8 @@ services:
     image: seleniarm/standalone-chromium:114.0
     ports:
       - "4444:4444"
+    profiles:
+      - test
 volumes:
   bundle_data:
   postgresql_data:

--- a/render.yaml
+++ b/render.yaml
@@ -7,15 +7,16 @@ databases:
 services:
   - type: web
     name: AI_dialogue_app
-    runtime: ruby
+    runtime: docker
+    region: singapore
+    branch: master
     plan: free
-    buildCommand: "./bin/render-build.sh"
-    # preDeployCommand: "bundle exec rails db:migrate" # preDeployCommand only available on paid instance types
-    startCommand: "bundle exec puma -C config/puma.rb"
+    dockerfilePath: ./Dockerfile
+    domains:
+      - ai-dialogue.jp
     envVars:
       - key: DATABASE_URL
         fromDatabase:
-          name: AI_dialogue_app
+          name: AI_dialogue_app_db
           property: connectionString
-      - key: RAILS_MASTER_KEY
-        sync: false
+

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -69,7 +69,7 @@ RSpec.configure do |config|
   # config.filter_gems_from_backtrace("gem name")
 
   config.include FactoryBot::Syntax::Methods
-  
+
   config.before(:each, type: :system) do
     driven_by :remote_chrome
     Capybara.server_host = IPSocket.getaddress(Socket.gethostname)


### PR DESCRIPTION
github actionsの一環としてあるCIの為に.github/workflows/ci.ymlを編集、rspecのテストが自動で作動するようにしてみた。

また、前回のデプロイで追加されたテスト用サーバーのchromeのサービスがデプロイに要する時間に大いに影響したので、profilesで通常のdocker compose upでは立ち上がらないように変更してみた。
デプロイが変わらず時間が掛かるようなら、別の方法を検討する。